### PR TITLE
feat: compatibility PrestaShop 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ]
   },
   "require": {
-    "php": ">=5.6",
-    "guzzlehttp/guzzle": "~6"
+    "php": "^7.2.5 || ^8.0",
+    "guzzlehttp/guzzle": "~7"
   },
   "require-dev": {
     "prestashop/php-dev-tools": "^4.2"


### PR DESCRIPTION
### Added

- Support PrestaShop 8
- Support PHP >= 7.2.5